### PR TITLE
Fixed crash on Linux

### DIFF
--- a/ProcessingNET/Shader.cs
+++ b/ProcessingNET/Shader.cs
@@ -47,6 +47,12 @@ namespace ProcessingNET
         {
             App = app;
 
+            // Strip byte order marks off shaders, which cause compilation errors on Linux
+            if(vertexSource.StartsWith('\ufeff'))
+                vertexSource = vertexSource.Substring(1);
+            if(fragmentSource.StartsWith('\ufeff'))
+                fragmentSource = fragmentSource.Substring(1);
+
             int vertexShader = GL.CreateShader(ShaderType.VertexShader);
             GL.ShaderSource(vertexShader, vertexSource);
             GL.CompileShader(vertexShader);


### PR DESCRIPTION
Shader compilation would always crash for the fragment shader.
Fixed by removing byte order marks before compiling shaders.